### PR TITLE
Update mm-broadband-modem-mbim.c

### DIFF
--- a/src/mm-broadband-modem-mbim.c
+++ b/src/mm-broadband-modem-mbim.c
@@ -2845,7 +2845,7 @@ before_set_lte_attach_configuration_query_ready (MbimDevice   *device,
         configurations[i]->user_name = g_strdup (mm_bearer_properties_get_user (config));
 
         g_clear_pointer (&(configurations[i]->password), g_free);
-        configurations[i]->password = g_strdup (mm_bearer_properties_get_user (config));
+        configurations[i]->password = g_strdup (mm_bearer_properties_get_password (config));
 
         configurations[i]->source = MBIM_CONTEXT_SOURCE_USER;
         configurations[i]->compression = MBIM_COMPRESSION_NONE;


### PR DESCRIPTION
        configurations[i]->user_name = g_strdup (mm_bearer_properties_get_user (config));

        g_clear_pointer (&(configurations[i]->password), g_free);
        configurations[i]->password = g_strdup (mm_bearer_properties_get_user (config));

        I'm not sure why the user_name password uses the same interface function. ????